### PR TITLE
Fix: Align back button with gallery content

### DIFF
--- a/new_static_site/gallery.html
+++ b/new_static_site/gallery.html
@@ -55,13 +55,12 @@
         </header>
 
         <main class="flex-1 pt-16 bg-light dark:bg-dark">
-            <a href="javascript:history.back()" title="Go Back"
-               class="fixed top-20 left-4 sm:left-6 lg:left-8 sm:top-8 z-[60] bg-white dark:bg-dark-lighter hover:bg-light-darker dark:hover:bg-dark-accent p-3 sm:p-4 rounded-lg transition-all duration-300 group shadow-lg">
-                <svg class="w-6 h-6 text-primary group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-            </a>
-
             <div class="pt-12 pb-16 min-h-screen">
                 <div class="max-w-7xl mx-auto px-4">
+                    <a href="javascript:history.back()" title="Go Back"
+                       class="mb-4 sm:mb-6 lg:mb-8 bg-white dark:bg-dark-lighter hover:bg-light-darker dark:hover:bg-dark-accent p-3 sm:p-4 rounded-lg transition-all duration-300 group shadow-lg inline-block">
+                        <svg class="w-6 h-6 text-primary group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    </a>
                     <h1 class="text-4xl font-bold mb-12 text-center text-gray-900 dark:text-white animate-on-scroll fade-in-up">
                         Photo Gallery
                     </h1>


### PR DESCRIPTION
Moved the back button within the main content container in gallery.html. Removed fixed positioning and applied margin for better alignment and responsiveness.