### PR TITLE
Add SVG default avatar and update JS reference

### DIFF
--- a/new_static_site/assets/default-avatar.svg
+++ b/new_static_site/assets/default-avatar.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#e0e0e0" /> <!-- Light grey background -->
+  <circle cx="50" cy="40" r="20" fill="#a0a0a0" /> <!-- Head shape -->
+  <path d="M30,90 C30,70 70,70 70,90 Z" fill="#a0a0a0" /> <!-- Body shape (simplified trapezoid for shoulders/body) -->
+</svg>

--- a/new_static_site/js/main.js
+++ b/new_static_site/js/main.js
@@ -309,7 +309,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const nameTextClass = screenWidth < 768 ? 'text-base md:text-lg' : 'text-lg lg:text-xl'; // Mobile: 16px, Desktop: 18-20px
         const roleTextClass = screenWidth < 768 ? 'text-xs md:text-sm' : 'text-sm lg:text-base'; // Mobile: 12-13px, Desktop: 14-16px
 
-        const placeholderImageSrc = "assets/default-avatar.png"; // Use the user-provided filename
+        const placeholderImageSrc = "assets/default-avatar.svg"; // Use the newly created SVG placeholder
 
         let imageContent;
         if (member.photoUrl && member.photoUrl.trim() !== "") {


### PR DESCRIPTION
- Created `new_static_site/assets/default-avatar.svg` with a simple placeholder graphic.
- Modified `new_static_site/js/main.js` to update the `placeholderImageSrc` variable to use `default-avatar.svg` instead of the previously missing `default-avatar.png`.

This addresses the issue of broken images for team members who do not have a specific photoUrl defined, by providing a generic SVG placeholder.