### PR TITLE
Implement simplified headers for sub-pages

### DIFF
--- a/new_static_site/gallery.html
+++ b/new_static_site/gallery.html
@@ -11,45 +11,28 @@
 </head>
 <body class="bg-light dark:bg-dark text-dark dark:text-white antialiased">
     <div id="app-container" class="min-h-screen flex flex-col">
-        <!-- Navbar Placeholder -->
-        <header id="navbar-container" class="fixed w-full z-50 bg-white/95 dark:bg-dark/95 backdrop-blur-sm">
-             <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <!-- Simplified Page Header -->
+        <header id="page-header-container" class="fixed w-full z-50 bg-white/95 dark:bg-dark/95 backdrop-blur-sm shadow-md">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="flex items-center justify-between h-16">
-                    <a href="index.html#home" class="fidipa-logo text-dark dark:text-white font-bold text-xl hover:scale-105 active:scale-95 transition-transform duration-150">FIDIPA</a>
-                    <div class="hidden md:flex items-center space-x-4">
-                        <div class="flex items-baseline space-x-1" id="desktop-nav-links">
-                            <a href="index.html#home" data-navid="home" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Home <span class="active-indicator"></span></a>
-                            <a href="index.html#about" data-navid="about" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">About <span class="active-indicator"></span></a>
-                            <a href="index.html#programs" data-navid="programs" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Programs <span class="active-indicator"></span></a>
-                            <a href="index.html#team" data-navid="team" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Team <span class="active-indicator"></span></a>
-                            <a href="index.html#gallery" data-navid="gallery" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Gallery <span class="active-indicator"></span></a>
-                            <a href="index.html#contact" data-navid="contact" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Contact <span class="active-indicator"></span></a>
-                        </div>
-                        <button id="theme-toggle-desktop" aria-label="Toggle theme" class="theme-toggle-button p-2 rounded-full hover:bg-gray-100 dark:hover:bg-dark-lighter transition-colors hover:scale-110 active:scale-90 duration-150">
+                    <!-- Back Button -->
+                    <a href="javascript:history.back()" title="Go Back" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-dark-lighter transition-colors group">
+                        <svg class="w-6 h-6 text-primary group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    </a>
+
+                    <!-- Page Title -->
+                    <h1 class="text-xl font-semibold text-dark dark:text-white">Photo Gallery</h1>
+
+                    <!-- Right side items: Logo (small) and Theme Toggle -->
+                    <div class="flex items-center space-x-4">
+                        <a href="index.html#home" class="fidipa-logo text-dark dark:text-white font-bold text-lg hover:scale-105 active:scale-95 transition-transform duration-150">
+                            FIDIPA
+                        </a>
+                        <button id="theme-toggle-page" aria-label="Toggle theme" class="theme-toggle-button p-2 rounded-full hover:bg-gray-100 dark:hover:bg-dark-lighter transition-colors hover:scale-110 active:scale-90 duration-150">
                             <svg class="sun-icon w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-15.66l-.707.707M4.04 19.96l-.707.707M21 12h-1M4 12H3m15.66 8.66l-.707-.707M4.04 4.04l-.707-.707"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18a6 6 0 100-12 6 6 0 000 12z"></path></svg>
                             <svg class="moon-icon w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
                         </button>
                     </div>
-                    <div class="md:hidden flex items-center space-x-2">
-                        <button id="theme-toggle-mobile" aria-label="Toggle theme" class="theme-toggle-button p-2 text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:scale-110 active:scale-90 transition-transform duration-150">
-                            <svg class="sun-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-15.66l-.707.707M4.04 19.96l-.707.707M21 12h-1M4 12H3m15.66 8.66l-.707-.707M4.04 4.04l-.707-.707"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18a6 6 0 100-12 6 6 0 000 12z"></path></svg>
-                            <svg class="moon-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
-                        </button>
-                        <button id="mobile-menu-button" aria-label="Open menu" class="p-2 text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:scale-110 active:scale-90 transition-transform duration-150">
-                            <svg id="menu-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
-                            <svg id="x-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-                        </button>
-                    </div>
-                </div>
-            </nav>
-            <div id="mobile-menu" class="md:hidden bg-white/95 dark:bg-dark-lighter/95 backdrop-blur-sm overflow-hidden max-h-0 opacity-0">
-                <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3" id="mobile-nav-links">
-                    <a href="index.html#home" data-navid="home" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Home</a>
-                    <a href="index.html#about" data-navid="about" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">About</a>
-                    <a href="index.html#programs" data-navid="programs" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Programs</a>
-                    <a href="index.html#team" data-navid="team" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Team</a>
-                    <a href="index.html#gallery" data-navid="gallery" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Gallery</a>
-                    <a href="index.html#contact" data-navid="contact" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Contact</a>
                 </div>
             </div>
         </header>
@@ -57,10 +40,7 @@
         <main class="flex-1 pt-16 bg-light dark:bg-dark">
             <div class="pt-12 pb-16 min-h-screen">
                 <div class="max-w-7xl mx-auto px-4">
-                    <a href="javascript:history.back()" title="Go Back"
-                       class="mb-4 sm:mb-6 lg:mb-8 bg-white dark:bg-dark-lighter hover:bg-light-darker dark:hover:bg-dark-accent p-3 sm:p-4 rounded-lg transition-all duration-300 group shadow-lg inline-block">
-                        <svg class="w-6 h-6 text-primary group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-                    </a>
+                    <!-- Removed the old back button that was here -->
                     <h1 class="text-4xl font-bold mb-12 text-center text-gray-900 dark:text-white animate-on-scroll fade-in-up">
                         Photo Gallery
                     </h1>

--- a/new_static_site/js/main.js
+++ b/new_static_site/js/main.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  // --- Mobile Menu ---
+  // --- Mobile Menu (Only for main navbar, so check if it exists) ---
   const mobileMenuButton = document.getElementById('mobile-menu-button');
   const mobileMenu = document.getElementById('mobile-menu');
   const menuIcon = document.getElementById('menu-icon');
@@ -35,14 +35,25 @@ document.addEventListener('DOMContentLoaded', () => {
       const isOpen = mobileMenu.classList.toggle('open');
       mobileMenu.classList.toggle('max-h-0', !isOpen);
       mobileMenu.classList.toggle('opacity-0', !isOpen);
-      // mobileMenu.classList.toggle('max-h-screen'); // Or a specific max height like max-h-[calc(100vh-4rem)]
-
       menuIcon.classList.toggle('hidden', isOpen);
       xIcon.classList.toggle('hidden', !isOpen);
     });
+
+    // Close mobile menu when a link is clicked (specific to main navbar's mobile menu)
+    const mobileNavLinks = mobileMenu.querySelectorAll('a');
+    mobileNavLinks.forEach(link => {
+      link.addEventListener('click', () => {
+        if (mobileMenu.classList.contains('open')) {
+          mobileMenu.classList.remove('open');
+          mobileMenu.classList.add('max-h-0', 'opacity-0');
+          if(menuIcon) menuIcon.classList.remove('hidden');
+          if(xIcon) xIcon.classList.add('hidden');
+        }
+      });
+    });
   }
 
-  // --- Capacity Statement Read More Toggle ---
+  // --- Capacity Statement Read More Toggle (on index.html) ---
   const capacityReadMoreButton = document.getElementById('capacity-read-more-button');
   const capacityStatementContent = document.getElementById('capacity-statement-content');
 
@@ -53,65 +64,103 @@ document.addEventListener('DOMContentLoaded', () => {
 
     capacityReadMoreButton.addEventListener('click', () => {
       const isOpen = capacityStatementContent.classList.toggle('open');
-      // Max height for transition will be handled by CSS: .collapsible-content and .collapsible-content.open
-      // JS just toggles the class.
-
       if (buttonText) buttonText.textContent = isOpen ? "Show Less" : "Read More";
       if (chevronDown) chevronDown.classList.toggle('hidden', isOpen);
       if (chevronUp) chevronUp.classList.toggle('hidden', !isOpen);
     });
   }
 
-  // Close mobile menu when a link is clicked
-  const mobileNavLinks = mobileMenu ? mobileMenu.querySelectorAll('a') : [];
-  mobileNavLinks.forEach(link => {
-    link.addEventListener('click', () => {
-      if (mobileMenu.classList.contains('open')) {
-        mobileMenu.classList.remove('open');
-        mobileMenu.classList.add('max-h-0', 'opacity-0');
-        menuIcon.classList.remove('hidden');
-        xIcon.classList.add('hidden');
-      }
-    });
-  });
+  // --- Smooth Scrolling & Active Section Highlighting (Only for main navbar on index.html) ---
+  const mainNavbar = document.getElementById('navbar-container'); // This ID is on the main navbar
+  const pageHeader = document.getElementById('page-header-container'); // This ID is on the new page headers
 
+  if (mainNavbar && !pageHeader) { // Only run this block if it's the main page with the full navbar
+    const navLinks = mainNavbar.querySelectorAll('.nav-link');
+    const sections = document.querySelectorAll('section[id]'); // Assumes sections are direct children or easily queryable
+    const navbarHeight = mainNavbar.offsetHeight || 64;
 
-  // --- Smooth Scrolling & Active Section Highlighting ---
-  const navLinks = document.querySelectorAll('.nav-link'); // Covers both desktop and mobile
-  const sections = document.querySelectorAll('section[id]');
-  const navbarHeight = document.getElementById('navbar-container')?.offsetHeight || 64; // h-16
-
-  // Smooth scroll for all nav links
-  navLinks.forEach(link => {
-    link.addEventListener('click', function(e) {
-      e.preventDefault();
-      const targetId = this.getAttribute('href');
-      if (targetId && targetId.startsWith('#')) {
-        const targetElement = document.querySelector(targetId);
-        if (targetElement) {
-          const elementPosition = targetElement.getBoundingClientRect().top + window.pageYOffset;
-          const offsetPosition = elementPosition - navbarHeight;
-
-          window.scrollTo({
-            top: offsetPosition,
-            behavior: 'smooth'
-          });
+    navLinks.forEach(link => {
+      link.addEventListener('click', function(e) {
+        const targetId = this.getAttribute('href');
+        // Only prevent default for internal links on the main page
+        if (targetId && targetId.startsWith('#')) {
+          e.preventDefault();
+          const targetElement = document.querySelector(targetId);
+          if (targetElement) {
+            const elementPosition = targetElement.getBoundingClientRect().top + window.pageYOffset;
+            const offsetPosition = elementPosition - navbarHeight;
+            window.scrollTo({
+              top: offsetPosition,
+              behavior: 'smooth'
+            });
+          }
         }
-      }
+        // For links like "programs.html", let the default navigation happen.
+      });
     });
-  });
 
-  // Smooth scroll for FIDIPA logo
-  const logoLink = document.querySelector('.fidipa-logo');
-  if (logoLink) {
-    logoLink.addEventListener('click', function(e) {
-      e.preventDefault();
-      const targetId = this.getAttribute('href');
-       if (targetId && targetId.startsWith('#')) {
-        const targetElement = document.querySelector(targetId);
-        if (targetElement) {
-          const elementPosition = targetElement.getBoundingClientRect().top + window.pageYOffset;
-          const offsetPosition = elementPosition - navbarHeight;
+    const updateActiveLink = () => {
+      let currentActiveId = null;
+      const scrollPosition = window.scrollY + navbarHeight + 1;
+
+      sections.forEach(section => {
+        const sectionTop = section.offsetTop;
+        const sectionHeight = section.offsetHeight;
+        if (scrollPosition >= sectionTop && scrollPosition < sectionTop + sectionHeight) {
+          currentActiveId = section.getAttribute('id');
+        }
+      });
+
+      if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 2) {
+        const lastSection = sections[sections.length - 1];
+        if (lastSection) currentActiveId = lastSection.id;
+      }
+
+      navLinks.forEach(link => {
+        const navId = link.getAttribute('data-navid');
+        if (navId === currentActiveId) {
+          link.classList.add('active');
+        } else {
+          link.classList.remove('active');
+        }
+      });
+    };
+
+    window.addEventListener('scroll', updateActiveLink);
+    updateActiveLink(); // Initial check
+  }
+
+  // Smooth scroll for FIDIPA logo (present on all pages, but behavior might differ)
+  // On index.html, it scrolls to #home. On other pages, it links to index.html#home.
+  // The `<a>` tag itself handles the navigation for non-index pages.
+  // We only need special JS handling for smooth scroll on index.html.
+  const logoLinks = document.querySelectorAll('.fidipa-logo'); // Might be multiple logos now
+  logoLinks.forEach(logoLink => {
+    if (logoLink) {
+      logoLink.addEventListener('click', function(e) {
+        const targetId = this.getAttribute('href');
+        if (targetId && targetId.startsWith('index.html#') && window.location.pathname.endsWith('index.html')) {
+          // If on index.html and clicking logo to go to a section on index.html
+          e.preventDefault();
+          const sectionId = targetId.split('#')[1];
+          const targetElement = document.getElementById(sectionId);
+          if (targetElement) {
+            const navbarHeight = document.getElementById('navbar-container')?.offsetHeight || 64; // Main navbar
+            const elementPosition = targetElement.getBoundingClientRect().top + window.pageYOffset;
+            const offsetPosition = elementPosition - navbarHeight;
+            window.scrollTo({
+              top: offsetPosition,
+              behavior: 'smooth'
+            });
+          }
+        } else if (targetId && targetId.startsWith('#') && mainNavbar && !pageHeader) {
+          // If on index.html and clicking logo to go to #home (or other section)
+          e.preventDefault();
+          const targetElement = document.querySelector(targetId);
+          if (targetElement) {
+            const navbarHeight = mainNavbar.offsetHeight || 64;
+            const elementPosition = targetElement.getBoundingClientRect().top + window.pageYOffset;
+            const offsetPosition = elementPosition - navbarHeight;
 
           window.scrollTo({
             top: offsetPosition,

--- a/new_static_site/programs.html
+++ b/new_static_site/programs.html
@@ -11,58 +11,34 @@
 </head>
 <body class="bg-light dark:bg-dark text-dark dark:text-white antialiased">
     <div id="app-container" class="min-h-screen flex flex-col">
-        <!-- Navbar Placeholder - Will be copied from index.html or dynamically inserted if we make it a component -->
-        <header id="navbar-container" class="fixed w-full z-50 bg-white/95 dark:bg-dark/95 backdrop-blur-sm">
-            <!-- Copied Navbar HTML from index.html -->
-            <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <!-- Simplified Page Header -->
+        <header id="page-header-container" class="fixed w-full z-50 bg-white/95 dark:bg-dark/95 backdrop-blur-sm shadow-md">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="flex items-center justify-between h-16">
-                    <a href="index.html#home" class="fidipa-logo text-dark dark:text-white font-bold text-xl hover:scale-105 active:scale-95 transition-transform duration-150">FIDIPA</a>
-                    <div class="hidden md:flex items-center space-x-4">
-                        <div class="flex items-baseline space-x-1" id="desktop-nav-links">
-                            <a href="index.html#home" data-navid="home" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Home <span class="active-indicator"></span></a>
-                            <a href="index.html#about" data-navid="about" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">About <span class="active-indicator"></span></a>
-                            <a href="index.html#programs" data-navid="programs" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Programs <span class="active-indicator"></span></a>
-                            <a href="index.html#team" data-navid="team" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Team <span class="active-indicator"></span></a>
-                            <a href="index.html#partners" data-navid="partners" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Partners <span class="active-indicator"></span></a>
-                            <a href="index.html#gallery" data-navid="gallery" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Gallery <span class="active-indicator"></span></a>
-                            <a href="index.html#contact" data-navid="contact" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white transition-colors duration-300 relative">Contact <span class="active-indicator"></span></a>
-                        </div>
-                        <button id="theme-toggle-desktop" aria-label="Toggle theme" class="theme-toggle-button p-2 rounded-full hover:bg-gray-100 dark:hover:bg-dark-lighter transition-colors hover:scale-110 active:scale-90 duration-150">
+                    <!-- Back Button -->
+                    <a href="javascript:history.back()" title="Go Back" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-dark-lighter transition-colors group">
+                        <svg class="w-6 h-6 text-primary group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+                    </a>
+
+                    <!-- Page Title -->
+                    <h1 class="text-xl font-semibold text-dark dark:text-white">Our Programs</h1>
+
+                    <!-- Right side items: Logo (small) and Theme Toggle -->
+                    <div class="flex items-center space-x-4">
+                        <a href="index.html#home" class="fidipa-logo text-dark dark:text-white font-bold text-lg hover:scale-105 active:scale-95 transition-transform duration-150">
+                            FIDIPA
+                        </a>
+                        <button id="theme-toggle-page" aria-label="Toggle theme" class="theme-toggle-button p-2 rounded-full hover:bg-gray-100 dark:hover:bg-dark-lighter transition-colors hover:scale-110 active:scale-90 duration-150">
                             <svg class="sun-icon w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-15.66l-.707.707M4.04 19.96l-.707.707M21 12h-1M4 12H3m15.66 8.66l-.707-.707M4.04 4.04l-.707-.707"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18a6 6 0 100-12 6 6 0 000 12z"></path></svg>
                             <svg class="moon-icon w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
                         </button>
                     </div>
-                    <div class="md:hidden flex items-center space-x-2">
-                        <button id="theme-toggle-mobile" aria-label="Toggle theme" class="theme-toggle-button p-2 text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:scale-110 active:scale-90 transition-transform duration-150">
-                            <svg class="sun-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-15.66l-.707.707M4.04 19.96l-.707.707M21 12h-1M4 12H3m15.66 8.66l-.707-.707M4.04 4.04l-.707-.707"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18a6 6 0 100-12 6 6 0 000 12z"></path></svg>
-                            <svg class="moon-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
-                        </button>
-                        <button id="mobile-menu-button" aria-label="Open menu" class="p-2 text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:scale-110 active:scale-90 transition-transform duration-150">
-                            <svg id="menu-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
-                            <svg id="x-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-                        </button>
-                    </div>
-                </div>
-            </nav>
-            <div id="mobile-menu" class="md:hidden bg-white/95 dark:bg-dark-lighter/95 backdrop-blur-sm overflow-hidden max-h-0 opacity-0">
-                <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3" id="mobile-nav-links">
-                    <a href="index.html#home" data-navid="home" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Home</a>
-                    <a href="index.html#about" data-navid="about" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">About</a>
-                    <a href="index.html#programs" data-navid="programs" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Programs</a>
-                    <a href="index.html#team" data-navid="team" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Team</a>
-                    <a href="index.html#partners" data-navid="partners" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Partners</a>
-                    <a href="index.html#gallery" data-navid="gallery" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Gallery</a>
-                    <a href="index.html#contact" data-navid="contact" class="nav-link block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-600 dark:text-gray-300 hover:text-dark dark:hover:text-white hover:bg-gray-100/30 dark:hover:bg-dark-accent/30">Contact</a>
                 </div>
             </div>
         </header>
 
         <main class="flex-1 pt-16 bg-light dark:bg-dark">
-            <a href="javascript:history.back()" title="Go Back"
-               class="fixed top-20 left-4 sm:left-6 lg:left-8 sm:top-8 z-[60] bg-white dark:bg-dark-lighter hover:bg-light-darker dark:hover:bg-dark-accent p-3 sm:p-4 rounded-lg transition-all duration-300 group shadow-lg">
-                <svg class="w-6 h-6 text-primary group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
-            </a>
-
+            <!-- Removed the old fixed back button that was here -->
             <div class="pt-12 pb-16 min-h-screen">
                 <div class="max-w-7xl mx-auto px-4">
                     <h1 class="text-4xl font-bold mb-12 text-center text-gray-900 dark:text-white animate-on-scroll fade-in-up">


### PR DESCRIPTION
- Replaced the main navigation bar on 'programs.html' and 'gallery.html' with a new simplified header.
- The new header contains a back button, the page title, the FIDIPA logo (linking to home), and a theme toggle button.
- The header is fixed at the top and remains visible on scroll.
- Removed old standalone back buttons from these pages.
- Updated JavaScript to conditionally initialize main navbar features (mobile menu, smooth scroll, active highlighting) to prevent errors on pages where this navbar is not present.
- Ensured theme toggle functionality remains consistent across all pages.
- Verified that main content is not obscured by the new fixed header.