### PR TITLE
Fix: Remove JS reference to non-existent image

### DIFF
--- a/new_static_site/js/main.js
+++ b/new_static_site/js/main.js
@@ -460,7 +460,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'assets/Youth engagement in land advocacy.jpg',
         'assets/SOFT SKILLS SESSIONS.jpg',
         'assets/Linda talking girls Sabako.jpg',
-        'assets/Youth program by Linda.jpg',
+        // 'assets/Youth program by Linda.jpg', // Removed as it does not exist
         'assets/YOUTH-LED COMMUNITY DIALOGUE.jpg'
       ],
       content: ""


### PR DESCRIPTION
Analyzed HTML, CSS, and JS files for image references. Removed a single reference in new_static_site/js/main.js within the programsData array that pointed to 'assets/Youth program by Linda.jpg', as this image file does not exist in the assets directory.

All other image references were either to existing assets or to 'default-avatar.svg' and were left untouched as per the defined scope.