### PR TITLE
Feat: Add site logo to navbar

### DIFF
--- a/new_static_site/index.html
+++ b/new_static_site/index.html
@@ -16,7 +16,8 @@
       <header id="navbar-container" class="fixed w-full z-50 bg-white/95 dark:bg-dark/95 backdrop-blur-sm">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div class="flex items-center justify-between h-16">
-            <a href="#home" class="fidipa-logo text-dark dark:text-white font-bold text-xl hover:scale-105 active:scale-95 transition-transform duration-150">
+            <a href="#home" class="fidipa-logo text-dark dark:text-white font-bold text-xl hover:scale-105 active:scale-95 transition-transform duration-150 flex items-center">
+              <img src="assets/fidipa logo (2).jpg" alt="FIDIPA Logo" class="h-8 w-8 mr-2"> <!-- Added logo -->
               FIDIPA
             </a>
 


### PR DESCRIPTION
- Added the site's favicon image (fidipa logo (2).jpg) to the left of the 'FIDIPA' text in the main navigation bar.
- Used Tailwind CSS classes to ensure proper alignment, sizing, and spacing of the logo and text.
- The logo is now part of the main site branding in the header.