### PR TITLE
Style: Clamp partner text to 2 lines and update parallax BG

### DIFF
--- a/new_static_site/css/style.css
+++ b/new_static_site/css/style.css
@@ -2087,8 +2087,17 @@ html.dark .moon-icon {
 
 /* Ensure partner text is fully visible */
 .partner-logo-item p {
-  /* Removed line clamping properties */
-  /* Text will now wrap naturally. Height of .partner-logo-item will adjust. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Ensure text alignment is good if it's less than 2 lines */
+  line-height: 1.4; /* Adjust as needed for your font */
+  max-height: calc(1.4em * 2); /* line-height * number of lines */
+  /* The parent .partner-logo-item already uses flex and items-center,
+     so text should be vertically centered if it's shorter than max-height.
+     No specific change needed here unless visual inspection shows otherwise. */
 }
 
 

--- a/new_static_site/index.html
+++ b/new_static_site/index.html
@@ -193,7 +193,7 @@
           </div>
         </section>
         <section id="programs" class="py-20 relative bg-light dark:bg-dark overflow-hidden"> {/* Added overflow-hidden to the section */}
-          <div id="programs-parallax-bg" class="absolute inset-x-0 top-0 h-[150%] bg-cover bg-center opacity-50 dark:opacity-40" style="background-image: url('./assets/lifeskills sessions in Kisumu.jpg');"></div> {/* Changed ID, removed bg-fixed, adjusted height for movement */}
+          <div id="programs-parallax-bg" class="absolute inset-x-0 top-0 h-[150%] bg-cover bg-center opacity-50 dark:opacity-40" style="background-image: url('./assets/FARM 1 - WWD .JPG');"></div> {/* Changed ID, removed bg-fixed, adjusted height for movement */}
           <div class="absolute inset-0 bg-white/80 dark:bg-dark/60 backdrop-blur-[2px]"></div>
 
           <div class="max-w-7xl mx-auto px-4 relative z-10">


### PR DESCRIPTION
- I modified CSS for the partners section to limit partner names to a maximum of 2 lines with an ellipsis for overflow.
- I verified that partner card height is sufficient.
- I changed the parallax background image for the 'Our Programs' section to a more suitable one from the assets folder, addressing visibility issues.
- I verified responsive widths for partner cards are acceptable with the new text clamping.